### PR TITLE
test: don't assert backend-specific error text for missing-file read

### DIFF
--- a/test/sql/pathvariable_read.test
+++ b/test/sql/pathvariable_read.test
@@ -140,10 +140,10 @@ NULL
 statement ok
 SET VARIABLE bad_path = '/nonexistent/path/to/file.txt';
 
+# Error text varies by filesystem backend (native: "Cannot open file";
+# wasm/emscripten: "ENOENT ..."), so assert only that it errors, not the message.
 statement error
 SELECT * FROM read_text('pathvariable:bad_path');
-----
-Cannot open file
 
 # =============================================================================
 # Type validation: non-VARCHAR/BLOB types should fail


### PR DESCRIPTION
test: don't assert backend-specific error text for missing-file read

pathvariable_read.test asserted the exact error message "Cannot open file" for
reading a nonexistent file. That text is filesystem-backend-specific: the native
LocalFileSystem produces "Cannot open file ...", but the wasm/emscripten backend
produces "ENOENT: no such file or directory", so the test fails under wasm
(surfaced by the haybarn duckdb-wasm functional tester) for no real reason.

Relax to a bare `statement error` so it asserts the read errors without pinning
the platform-specific message. Native behavior is unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
